### PR TITLE
Prevent errors on first invocation

### DIFF
--- a/rcirc-groups.el
+++ b/rcirc-groups.el
@@ -167,9 +167,8 @@
 
 (defun rcirc-groups:list-conversations ()
   "list all conversations where some notification has not yet been acknowledged"
-  (let ((groups-buffer (get-buffer rcirc-groups:buffer-name)))
-    (unless groups-buffer (rcirc-groups:create-notify-buffer))
-
+  (let ((groups-buffer (or (get-buffer rcirc-groups:buffer-name)
+                           (rcirc-groups:create-notify-buffer))))
     (with-current-buffer groups-buffer
       (let ((inhibit-read-only t))
 	(erase-buffer)


### PR DESCRIPTION
The group buffer creation code in `rcirc-groups:list-conversations` was
incorrect and ended up calling `with-current-buffer` using `nil` as the
value for the buffer name when handling the first IRC message, causing
an "(wrong-type-argument stringp nil)" error.
