### PR TITLE
Fix failure seemingly introduced by Emacs 25

### DIFF
--- a/rcirc-groups.el
+++ b/rcirc-groups.el
@@ -35,7 +35,7 @@
 
 (defun rcirc-groups:conversation-has-been-killed (conversation-entry)
   "returns t only when conversation's buffer has been killed"
-  (endp (buffer-name (car conversation-entry))))
+  (string= "" (buffer-name (car conversation-entry))))
 
 (defun rcirc-groups:format-conversation (conversation-entry)
   "pretty print a conversation in a propertized string, return the string"


### PR DESCRIPTION
Use string= instead of endp for checking of an empty string.

endp now checks if it's a list, and a string does not qualify.